### PR TITLE
Avoid generating many layers with the same name in one map.tmx file.

### DIFF
--- a/gmgmap/tmx.go
+++ b/gmgmap/tmx.go
@@ -127,7 +127,8 @@ func (m Map) ToTMX(rr *rand.Rand, tmxTemplate *TMXTemplate, imgId int) error {
 	if err != nil {
 		return err
 	}
-
+	// Avoid generating many layers with the same name in one map.tmx file.
+	tmxTemplate.CSVs = make([]csvExport, 0)
 	populateTemplate(rr, m, tmxTemplate)
 
 	// Generate TMX


### PR DESCRIPTION
Avoid generating many layers with the same name.
**Before**
![image](https://github.com/user-attachments/assets/d226ccfa-1107-45ef-9e78-20cd3f56b352)

**After**
![image](https://github.com/user-attachments/assets/583184af-40ff-42dc-982a-d948b0e9d51d)
